### PR TITLE
ipython_pygments_lexers 1.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,8 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
+  doc_url: https://github.com/ipython/ipython-pygments-lexers
+  dev_url: https://github.com/ipython/ipython-pygments-lexers
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81
 
 build:
-  noarch: python
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,18 +16,18 @@ build:
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - pip
     - flit-core
   run:
-    - python >={{ python_min }}
+    - python
     - pygments
 
 test:
   imports:
     - ipython_pygments_lexers
   requires:
-    - python {{ python_min }}
+    - python
     - pip
   commands:
     - pip check


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7978](https://anaconda.atlassian.net/browse/PKG-7978)
- [Upstream repository](https://github.com/ipython/ipython-pygments-lexers/tree/1.1.1)

### Explanation of changes:

- Fork from conda forge
- Remove noarch
- Recipe cleanup
- Linter fixes


[PKG-7978]: https://anaconda.atlassian.net/browse/PKG-7978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ